### PR TITLE
Fix rubocop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     konvenit_style (0.1.0)
-      rubocop (~> 0.51.0)
+      rubocop (~> 0.52.0)
       rubocop-checkstyle_formatter (~> 0.4.0)
 
 GEM
@@ -13,14 +13,13 @@ GEM
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (10.5.0)
-    rubocop (0.51.0)
+    rubocop (0.52.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-checkstyle_formatter (0.4.0)

--- a/konvenit_style.gemspec
+++ b/konvenit_style.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'rubocop', '~> 0.51.0'
+  spec.add_dependency 'rubocop', '~> 0.52.0'
   spec.add_dependency 'rubocop-checkstyle_formatter', "~> 0.4.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -129,7 +129,7 @@ Style/UnneededPercentQ:
 ## good
 #def value?
 #end
-Style/PredicateName:
+Style/Naming:
   Enabled: false
 
 # Layout


### PR DESCRIPTION
Upgrade rubocop gem to allow style check on ruby 2.5